### PR TITLE
add locale export for en_US (#38)

### DIFF
--- a/pacmn.sh
+++ b/pacmn.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+export LC_ALL="en_US.UTF-8"
+
 if [ "$1" == "--testnet" ]; then
 	pac_rpc_port=17111
 	pac_port=17112


### PR DESCRIPTION
some users who have a different locale auto set their locale when they ssh into a remote vps, which causes failures in the pip installs for sentinel. This should be safe.